### PR TITLE
Resolve Issue #10 Change string to enum on GetServicesByType()

### DIFF
--- a/backend/controllers/service.go
+++ b/backend/controllers/service.go
@@ -16,31 +16,12 @@ import (
 	"gorm.io/gorm"
 )
 
-type ServiceType string
-
-const (
-	Analytic	ServiceType = "analytic"
-	Solution				= "solution"
-	Innovation				= "innovation"
-)
-
-func isValidServiceType(serviceType string) (bool, ServiceType) {
-	serviceTypes := [...]ServiceType{Analytic, Solution, Innovation}
-	for _, st := range serviceTypes {
-		if string(st) == serviceType {
-			return true, st
-		}
-	}
-
-	return false, ""
-}
-
 func GetServicesByType(ctx *gin.Context) {
 	serviceTypeQuery, isAnyQueryType := ctx.GetQuery("type")
 
 	// check if there is a query URL "type" 
 	// and it has an invalid value
-	isValid, serviceType := isValidServiceType(serviceTypeQuery)
+	isValid, serviceType := models.IsValidServiceType(serviceTypeQuery)
 	if isAnyQueryType && !isValid {
 		ctx.JSON(http.StatusBadRequest, gin.H {
 			"ok": false,
@@ -50,11 +31,11 @@ func GetServicesByType(ctx *gin.Context) {
 	}
 
 	switch serviceType {
-	case Analytic:
+	case models.Analytic:
 		getServiceAnalytic(ctx)
-	case Solution:
+	case models.Solution:
 		getServiceSolution(ctx)
-	case Innovation:
+	case models.Innovation:
 		getServiceInnovation(ctx)
 	// handle conditions like /services, /services?types=analytic
 	default:

--- a/backend/models/service.go
+++ b/backend/models/service.go
@@ -6,6 +6,14 @@ import (
 	"gorm.io/gorm"
 )
 
+type ServiceType string
+
+const (
+	Analytic	ServiceType = "analytic"
+	Solution				= "solution"
+	Innovation				= "innovation"
+)
+
 type Service struct {
 	ID               uint 		`gorm:"primaryKey; autoIncrement" json:"id"` 
 	ApiKey           string 	`json:"api_key"`
@@ -58,4 +66,15 @@ func CreateService(db *gorm.DB, Service *Service) (err error) {
 		return err
 	}
 	return nil
+}
+
+func IsValidServiceType(serviceType string) (bool, ServiceType) {
+	serviceTypes := [...]ServiceType{Analytic, Solution, Innovation}
+	for _, st := range serviceTypes {
+		if string(st) == serviceType {
+			return true, st
+		}
+	}
+
+	return false, ""
 }


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Enhancement
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
Predefined service type on GetServicesByType() in service controllers still uses string data type.

## What is the new behavior?
As per @krismp request to use Enum type for predefined value which in this case is in "service type" in service controller.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No