### PR TITLE
[Beat] Sub-grouping existing routes to group /api/v1

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -68,7 +68,7 @@ Create a visitor and generate the session id.
 
 - **URL**
 
-  `/visitors`
+  `/api/v1/visitors`
 
 - **Method**
 
@@ -158,7 +158,7 @@ Create a visitor activity.
 
 - **URL**
 
-  `/activities`
+  `/api/v1/activities`
 
 - **Method**
 
@@ -232,7 +232,7 @@ Create a service request by id and create a new visitor_activites record.
 
 - **URL**
 
-  `/services/:id`
+  `/api/v1/services/:id`
 
 - **Method**
 
@@ -356,7 +356,7 @@ Return json data about all Services.
 
 - **URL**
 
-  `/services`
+  `/api/v1/services`
 
 - **Method**
 
@@ -442,7 +442,7 @@ Return json data about all Services by type.
 
 - **URL**
 
-  `/services?type=`
+  `/api/v1/services?type=`
 
 - **Method**
 
@@ -525,7 +525,7 @@ Return json data about a Service by slug.
 
 - **URL**
 
-  `/services/:slug`
+  `/api/v1/services/:slug`
 
 - **Method**
 
@@ -601,7 +601,7 @@ Return json data about a Service by slug.
 
 - **URL**
 
-  `/feedback/:service_id`
+  `/api/v1/feedback/:service_id`
 
 - **Method**
 

--- a/backend/routes.go
+++ b/backend/routes.go
@@ -15,27 +15,30 @@ func SetupRouter() *gin.Engine {
 		ctx.JSON(http.StatusOK, "pong")
 	})
 
-	services := r.Group("/services")
+	apis := r.Group("/api/v1")
 	{
-		services.GET("", controllers.GetServices)
-		services.GET("/:slug", controllers.GetServiceBySlug)
-
-		services.POST("/:id", controllers.CreateServiceRequest)
-	}
-
-	visitors := r.Group("/visitors")
-	{
-		visitors.POST("", controllers.CreateVisitor)
-	}
-
-	activities := r.Group("/activities")
-	{
-		activities.POST("", controllers.CreateActivity)
-	}
-
-	feedbacks := r.Group("/feedback")
-	{
-		feedbacks.POST("/:service_id", controllers.CreateFeedback)
+		services := apis.Group("/services")
+		{
+			services.GET("", controllers.GetServices)
+			services.GET("/:slug", controllers.GetServiceBySlug)
+	
+			services.POST("/:id", controllers.CreateServiceRequest)
+		}
+	
+		visitors := apis.Group("/visitors")
+		{
+			visitors.POST("", controllers.CreateVisitor)
+		}
+	
+		activities := apis.Group("/activities")
+		{
+			activities.POST("", controllers.CreateActivity)
+		}
+	
+		feedbacks := apis.Group("/feedback")
+		{
+			feedbacks.POST("/:service_id", controllers.CreateFeedback)
+		}
 	}
 
 	return r


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
There's no base prefix URL for the existing API Endpoint, so it causes a problem issue when deploying in Kubernetes.

## What is the new behavior?
Sub-grouping existing routes to group `/api/v1`.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Now you need to add `/api/v1` in front of the existing endpoint when you are going to hit the backend api service. Example:
- GET `api/v1/services`
- GET `/api/v1/services/ocr-ktp`
- POST `/api/v1/feedback/:service_id` 