### PR TITLE
fix DropzoneOptions to use fixed width in dekstop

### DIFF
--- a/frontend/app/components/modules/DropzoneOptions/DropzoneOptions.module.scss
+++ b/frontend/app/components/modules/DropzoneOptions/DropzoneOptions.module.scss
@@ -36,7 +36,7 @@
       width: 80%;
     }
     .dropzoneContainer {
-      width: 100%;
+      width: 600px;
       height: 360px;
       position: relative;
       outline: 2px solid silver;
@@ -46,6 +46,7 @@
       }
       @include tablet {
         margin-left: unset;
+        width: 100%;
       }
     }
     .imageOptions {


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
<!-- Please describe the current behavior. -->
DropzoneOptions use percentages as width so its look so large in larger screen

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
fix DropzoneOptions to use fixed width in dekstop
## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have filled the `[Unreleased]` [Changelog](https://github.com/nodefluxio/weber/blob/main/CHANGELOG.md

## Security Pentester API Checklist
- [ ] IDOR
- [ ] Malicious Script Injection
- [ ] SQL Injection

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
![image](https://user-images.githubusercontent.com/45916985/141247232-bde9707d-ec99-464b-961d-b3ca5c928afd.png)
