### PR TITLE
[Beat] Reformat Phone Number in Face Payment Registration

### DIFF
--- a/backend/controllers/session.go
+++ b/backend/controllers/session.go
@@ -34,3 +34,16 @@ func (ctrl *Controller) IsSessionExpired(sessionId string) bool {
 
 	return dateNow.After(dateExpiration)
 }
+
+func (ctrl *Controller) GetExpirationDate(sessionId string) string {
+	expirationLimit, err := strconv.Atoi(os.Getenv("SESSION_EXPIRATION"))
+	if err != nil {
+		log.Fatal("environment variable 'SESSION_EXPIRATION' is not set")
+	}
+
+	var visitor models.Visitor
+	ctrl.Model.GetVisitor(&visitor, sessionId)
+	dateExpiration := visitor.CreatedAt.AddDate(0, 0, expirationLimit)
+
+	return dateExpiration.Format("02-01-2006 15:04:05")
+}

--- a/backend/models/face_payment.go
+++ b/backend/models/face_payment.go
@@ -21,7 +21,7 @@ type FacePaymentAccount struct {
 type NewAccountData struct {
 	SessionID string      `json:"session_id"`
 	FullName  string      `json:"full_name" validate:"required,min=2,max=255"`
-	Phone     string      `json:"phone" validate:"required,numeric"`
+	Phone     string      `json:"phone" validate:"required,numeric",min=5,max=15`
 	HaveTwin  *bool       `json:"have_twin" validate:"required"`
 	Data      RequestData `json:"data"`
 	CreatedAt time.Time   `json:"created_at"`

--- a/backend/models/face_payment.go
+++ b/backend/models/face_payment.go
@@ -21,7 +21,7 @@ type FacePaymentAccount struct {
 type NewAccountData struct {
 	SessionID string      `json:"session_id"`
 	FullName  string      `json:"full_name" validate:"required,min=2,max=255"`
-	Phone     string      `json:"phone" validate:"required,numeric,min=5,max=15"`
+	Phone     string      `json:"phone" validate:"required,numeric,min=12,max=15"`
 	HaveTwin  *bool       `json:"have_twin" validate:"required"`
 	Data      RequestData `json:"data"`
 	CreatedAt time.Time   `json:"created_at"`

--- a/backend/models/face_payment.go
+++ b/backend/models/face_payment.go
@@ -21,7 +21,7 @@ type FacePaymentAccount struct {
 type NewAccountData struct {
 	SessionID string      `json:"session_id"`
 	FullName  string      `json:"full_name" validate:"required,min=2,max=255"`
-	Phone     string      `json:"phone" validate:"required,numeric",min=5,max=15`
+	Phone     string      `json:"phone" validate:"required,numeric,min=5,max=15"`
 	HaveTwin  *bool       `json:"have_twin" validate:"required"`
 	Data      RequestData `json:"data"`
 	CreatedAt time.Time   `json:"created_at"`


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
The phone number is saved as an actual input


## What is the new behavior?
- The phone number is saved as DD{MM+YY}Phone because there is validation based on the expiration date of the visitor.
- There is a rule if the first character is 0 we will replace it with 62 because of the rules from Nodeflux's cloud.
- Added min 5 and max 15 validation

## Does this introduce a breaking change?

- [x] Yes
- [ ] No
