### PR TITLE
[Beat] Add Reset Balance Account on Face Payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- [BACKEND] Add HTTP Requester for OCR Receipt Recognition Innovation 
+- [BACKEND] Add HTTP Requester for OCR Receipt Recognition Innovation
+- [BACKEND] Add API Reset Balance Account on Face Payment
 
 ### Changed
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1428,3 +1428,47 @@ OR
 ```
 
 </details>
+
+<details>
+<summary><b>Reset Balance Face Payment Account</b></summary>
+Reset balance of face payment account to 1000000 (default)
+- **URL**
+
+`/api/v1/face-payment/reset-balance/:session_id`
+
+- **Method**
+
+  `PATCH`
+
+- **Sample Success Response**
+
+  **Code**: 200 OK
+
+```json
+{
+  "message": "The balance in this account has been reset successfully",
+  "ok": true
+}
+```
+
+- **Data Type Attributes**
+
+```json
+{
+   "message": string,
+   "ok": boolean
+}
+```
+
+- **Sample Error Response**
+
+  **Code**: 404 Not Found
+
+```json
+{
+  "message": "This session id does not have an active face payment account",
+  "ok": false
+}
+```
+
+</details>

--- a/backend/controllers/face_payment.go
+++ b/backend/controllers/face_payment.go
@@ -236,7 +236,9 @@ func (ctrl *Controller) ResetBalanceFacePaymentAccount(ctx *gin.Context) {
 
 	var accountWallet models.FacePaymentWallet
 	ctrl.Model.GetAccountWallet(&accountWallet, account.ID)
-	accountWallet.Balance = 1000000
+
+	const DEFAULT_BALANCE = 1000000
+	accountWallet.Balance = DEFAULT_BALANCE
 	ctrl.Model.UpdateBalance(&accountWallet)
 
 	ctx.JSON(http.StatusOK, gin.H{

--- a/backend/routes.go
+++ b/backend/routes.go
@@ -53,6 +53,7 @@ func SetupRouter(ctrl *controllers.Controller) *gin.Engine {
 			facePayments.POST("/pay", ctrl.CreateTransaction)
 
 			facePayments.PATCH("/account", ctrl.UpdateFacePaymentAccount)
+			facePayments.PATCH("/reset-balance/:session_id", ctrl.ResetBalanceFacePaymentAccount)
 		}
 	}
 


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
There is no API for reset balance face payment account


## What is the new behavior?
Added endpoint for reset balance face payment account to 1000000 (default)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Screenshot:
![Screenshot_2005](https://user-images.githubusercontent.com/10008683/142901705-d03c06ba-81ff-4b19-ac87-7c1b49c8145c.png)

