### PR TITLE
Change Sub heading font to Montserrat

### DIFF
--- a/frontend/app/components/templates/HomePage/HomePage.module.scss
+++ b/frontend/app/components/templates/HomePage/HomePage.module.scss
@@ -171,7 +171,7 @@
           font-weight: 800;
           font-family: $primary-font;
           &:nth-child(2) {
-            font-weight: 400;
+            font-weight: 500;
             font-family: $secondary-font;
             color: $white-text;
           }

--- a/frontend/app/components/templates/HomePage/HomePage.tsx
+++ b/frontend/app/components/templates/HomePage/HomePage.tsx
@@ -212,7 +212,7 @@ export const HomePage = ({ analytics, solutions, innovations }: Props) => {
                 className={styles.cardContent}
                 color={Color.Primary}
                 title={analytic.name}>
-                {analytic.short_description}
+                <p>{analytic.short_description}</p>
                 <div className={styles.footer}>
                   <Link href={'/analytics/' + analytic.slug} passHref>
                     <Button type="link" color={Color.Secondary}>
@@ -244,7 +244,7 @@ export const HomePage = ({ analytics, solutions, innovations }: Props) => {
                     className={styles.cardContent}
                     title={innovation.name}
                     height={'100%'}>
-                    {innovation.short_description}
+                    <p> {innovation.short_description}</p>
                     <div className={styles.footer}>
                       <Link href={'/innovations/' + innovation.slug} passHref>
                         <Button type="link" color={Color.Secondary}>

--- a/frontend/app/styles/abstracts/_variables.scss
+++ b/frontend/app/styles/abstracts/_variables.scss
@@ -6,7 +6,7 @@
 /// @type List
 // $primary-font: 'Raleway', sans-serif !default;
 $primary-font: 'Montserrat', sans-serif !default;
-$secondary-font: 'Hind', sans-serif !default;
+$secondary-font: 'Montserrat', sans-serif !default;
 $code-snippet-font: 'Consolas', ui-monospace, monospace;
 /// Colors
 /// @type Color

--- a/frontend/app/styles/base/_base.scss
+++ b/frontend/app/styles/base/_base.scss
@@ -11,6 +11,9 @@ h3 {
   font-weight: 700;
   font-family: $primary-font;
 }
+p {
+  line-height: 170%;
+}
 html,
 body {
   margin: 0;

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -18,7 +18,7 @@ class MainDocument extends Document {
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" />
           <link
-            href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700;800&family=Hind:wght@400;500;600;700&display=swap"
+            href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&display=swap"
             rel="stylesheet"
           />
           <link rel="shortcut icon" href="/favicon.ico" />


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
<!-- Please describe the current behavior. -->
Currently, sub-headings use font-family Hind

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
As requested, change change sub-head to use Montserrat

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have filled the `[Unreleased]` [Changelog](https://github.com/nodefluxio/weber/blob/main/CHANGELOG.md

## Security Pentester API Checklist
- [ ] IDOR
- [ ] Malicious Script Injection
- [ ] SQL Injection

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Before 
![image](https://user-images.githubusercontent.com/45916985/144151949-7f986329-2e6d-4601-9b9b-a46240336285.png)
After
![image](https://user-images.githubusercontent.com/45916985/144152002-83bff3fa-f600-4f28-a9c4-a18be0f3abdc.png)
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
