### PR TITLE
create optional onClick props on Responsive Image component

### DIFF
--- a/frontend/app/components/modules/ResponsiveImage/ResponsiveImage.tsx
+++ b/frontend/app/components/modules/ResponsiveImage/ResponsiveImage.tsx
@@ -6,11 +6,20 @@ type Props = {
   src: string
   alt: string
   objectFit: NonNullable<JSX.IntrinsicElements['img']['style']>['objectFit']
+  onClick?: () => void
 }
 
-export const ResponsiveImage = ({ className, src, alt, objectFit }: Props) => {
+export const ResponsiveImage = ({
+  className,
+  src,
+  alt,
+  objectFit,
+  onClick
+}: Props) => {
   return (
-    <div className={`${styles.responsiveImage} ${className}`}>
+    <div
+      className={`${styles.responsiveImage} ${className}`}
+      onClick={() => onClick && onClick()}>
       <Image src={src} alt={alt} layout="fill" objectFit={objectFit} />
     </div>
   )


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
<!-- Please describe the current behavior. -->
there are no onClick props on Responsive Image component. we should use another div if we want to add onClick event

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
added optional onclick props to Responsive Image component to solve problem stated above.

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have filled the `[Unreleased]` [Changelog](https://github.com/nodefluxio/weber/blob/main/CHANGELOG.md

## Security Pentester API Checklist
- [ ] IDOR
- [ ] Malicious Script Injection
- [ ] SQL Injection

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
