### PR TITLE
[Beat] Update Activities Endpoint for Solution Partner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ All notable changes to this project will be documented in this file.
 - [BACKEND] Add 5 new seed data for partner solution service
 - [BACKEND] Add new service type: `solution-partner`
 - [BACKEND] Add new controller to get services with service type: `solution-partner`
+- [BACKEND] Add new predefined visitor in seed that will be used for a solution partner
+- [BACKEND] Update visitor activities endpoint for solution partner
+- [BACKEND] Take out the unique index in service's slug
 
 ### Changed
+
 - [FRONTEND] Modified solution card stylings
 
 ### Removed

--- a/backend/database/seed.go
+++ b/backend/database/seed.go
@@ -31,15 +31,27 @@ func seedVisitor(model *models.Model) []string {
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 		},
+		{
+			SessionID: "SessionForSolutionPartner",
+			Email:     "nodeflux@nodeflux.io",
+			FullName:  "Nodeflux Autofill for Partner",
+			Company:   "Nodeflux",
+			JobTitle:  "Software Engineer",
+			Industry:  "Computer Vision",
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
 		// Add new visitor here
 	}
 
 	sessionIds := []string{}
 
 	for _, visitor := range visitors {
-		sessionId := uuid.New()
-		sessionIds = append(sessionIds, sessionId.String())
-		visitor.SessionID = sessionId.String()
+		if visitor.SessionID != "SessionForSolutionPartner" {
+			sessionId := uuid.New()
+			sessionIds = append(sessionIds, sessionId.String())
+			visitor.SessionID = sessionId.String()
+		}
 		model.CreateVisitor(&visitor)
 	}
 
@@ -178,7 +190,7 @@ func seedService(model *models.Model) {
 			Slug:               "ocr-receipt",
 			Thumbnail:          "ocr-receipt.png",
 			AccessKey:          "",
-			Token:				"",
+			Token:              "",
 			Timestamp:          "",
 			ShortDescription:   "OCR Receipt Recognition is one of the new innovations developed by Nodeflux (still experimental). This analytic has the ability to read and extract the characters on a shopping receipt issued by various supermarkets.",
 			LongDescription:    "Nodeflux has developed new technology that allows users to more easily extract data from receipts, called OCR Receipt Recognition. The following data can be extracted: product description, location, price, and total price. By extracting this data, sellers will be able to analyze buyer behavior, and prepare for campaigns, discounts, and cashback in order to set product prices, encourage product improvements, and promote products. In the future, this innovation will continue to improve.",
@@ -192,7 +204,7 @@ func seedService(model *models.Model) {
 			Slug:               "car-damage",
 			Thumbnail:          "car-damage.png",
 			AccessKey:          "",
-			Token:             	"",
+			Token:              "",
 			Timestamp:          "",
 			ShortDescription:   "Car Damage Assessment is one of the new innovations developed by Nodeflux (still experimental). This analytic has the ability to detect and assess the level of damage to a car.",
 			LongDescription:    "Nodeflux has developed a new technology that has the ability to detect and assess the level of damage to a car, called Car Damage Assessment. The parts of the damage that can be detected are the front side, wing (left and right) side, and back side of the car. This analytic also provides an assessment of the level of damage detected, so it can be used to help industries such as car insurance or car repair shops. In the future, this innovation will continue to improve.",
@@ -206,7 +218,7 @@ func seedService(model *models.Model) {
 			Slug:               "face-occlusion-attribute",
 			Thumbnail:          "face-occlusion-attribute.png",
 			AccessKey:          "",
-			Token:				"",
+			Token:              "",
 			Timestamp:          "",
 			ShortDescription:   "This analytics is a combination of face occlusion and face attributes. Face occlusion can detect the part of the face area that is occluded, while face attribute can detect the type of attribute found in the face area.",
 			LongDescription:    "This analytics is a combination of face occlusion and face attributes. Face occlusion can detect the part of the face area that is occluded, while face attribute can detect the type of attribute found in the face area. The combination of these two analytics can ensure the user's face is clearly visible and can safely perform the face liveness and face recognition processes.",
@@ -220,7 +232,7 @@ func seedService(model *models.Model) {
 			Slug:               "http://nodeflux-registration.komunestudio.com",
 			Thumbnail:          "road-traffic-monitoring.png",
 			AccessKey:          "",
-			Token:				"",
+			Token:              "",
 			Timestamp:          "",
 			ShortDescription:   "Road Traffic Monitoring (RTM) is used to monitor vehicle activity and traffic density in real time. RTM will provide real-time visual insight based on factual data in the field taken from CCTV in certain areas as observation points.",
 			LongDescription:    "",
@@ -234,7 +246,7 @@ func seedService(model *models.Model) {
 			Slug:               "https://app.caliana.id/auth?signup",
 			Thumbnail:          "hris.png",
 			AccessKey:          "",
-			Token:				"",
+			Token:              "",
 			Timestamp:          "",
 			ShortDescription:   "Caliana is equipped with a mobile application that can be used as a remote attendance system. Not only a presence application, Caliana mobile is also equipped with interesting features for the safety and comfort of your employees.",
 			LongDescription:    "",
@@ -248,7 +260,7 @@ func seedService(model *models.Model) {
 			Slug:               "https://apps.apple.com/id/app/jaki/id1509621798?l=id",
 			Thumbnail:          "citizen-apps.png",
 			AccessKey:          "",
-			Token:				"",
+			Token:              "",
 			Timestamp:          "",
 			ShortDescription:   "One platform for the various needs of Citizen.",
 			LongDescription:    "",

--- a/backend/models/service.go
+++ b/backend/models/service.go
@@ -9,17 +9,17 @@ import (
 type ServiceType string
 
 const (
-	AnalyticServiceType   		ServiceType = "analytic"
-	SolutionServiceType   		            = "solution"
-	InnovationServiceType 		            = "innovation"
-	SolutionPartnerServiceType				= "solution-partner"
+	AnalyticServiceType        ServiceType = "analytic"
+	SolutionServiceType                    = "solution"
+	InnovationServiceType                  = "innovation"
+	SolutionPartnerServiceType             = "solution-partner"
 )
 
 type Service struct {
 	ID                 uint `gorm:"primaryKey; autoIncrement" json:"id"`
 	Name               string
 	Type               string
-	Slug               string `gorm:"uniqueIndex"`
+	Slug               string
 	Thumbnail          string
 	AccessKey          string
 	Token              string
@@ -132,6 +132,29 @@ func (m *Model) GetServiceBySlug(Service *Service, slug string) (err error) {
 	log.WithFields(log.Fields{
 		"slug": slug,
 	}).Info("[MODEL: GetServiceBySlug] success on find service slug!")
+
+	return nil
+}
+
+func (m *Model) GetServiceById(Service *Service, id uint) (err error) {
+
+	log.WithFields(log.Fields{
+		"service": Service,
+		"id":      id,
+	}).Info("[MODEL: GetServiceById] get service by id start...")
+
+	err = m.DBConn.Where("id = ?", id).First(Service).Error
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"id":    id,
+		}).Error("[MODEL: GetServiceById] error on find service by id!")
+
+		return err
+	}
+	log.WithFields(log.Fields{
+		"id": id,
+	}).Info("[MODEL: GetServiceById] success on find service by id!")
 
 	return nil
 }


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
The activities endpoint is cannot be used for a solution partner, it's will error 401 when there is no session id)


## What is the new behavior?
- Create a predefined visitor in seed
- Update visitor activities endpoint so it will using predefined visitor when there is no session
- Take out the unique index in the service's slug because we will use slug for the partner's URL (it can be duplicated)

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

We need to run ```go run . seed``` to use predefined visitor

## Other information

Screenshot from Postman and Pgadmin:
![Screenshot_2055](https://user-images.githubusercontent.com/10008683/144891013-742cf63e-e26f-4df2-9d76-0640cdb27b27.png)
![Screenshot_2054](https://user-images.githubusercontent.com/10008683/144891020-3e857211-fdf8-4530-bef2-06903011cee4.png)


