### PR TITLE
[Frontend] Adjusting solution card text width

### DIFF
--- a/frontend/app/components/templates/HomePage/HomePage.module.scss
+++ b/frontend/app/components/templates/HomePage/HomePage.module.scss
@@ -214,7 +214,7 @@
           bottom: 0px;
           padding: 1.5rem;
           height: 60%;
-          width: inherit;
+          width: 100%;
           box-sizing: border-box;
           overflow: hidden;
           text-overflow: ellipsis;

--- a/frontend/app/components/templates/HomePage/HomePage.module.scss
+++ b/frontend/app/components/templates/HomePage/HomePage.module.scss
@@ -214,6 +214,7 @@
           bottom: 0px;
           padding: 1.5rem;
           height: 60%;
+          width: inherit;
           box-sizing: border-box;
           overflow: hidden;
           text-overflow: ellipsis;


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
<!-- Please describe the current behavior. -->
- The text container on solutions card had different widths which could be noticed when the copywriting provided had few words on mobile devices (thank you @sonadztux for reminding me of this issue)
<img src="https://user-images.githubusercontent.com/52844949/144978539-90f50aac-aabb-49e7-8157-bbcbb517199f.jpg" width="auto" height="640"/>

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- A css rule is added so the text container on solutions card had fixed width (same as the width of the card)
<img src="https://user-images.githubusercontent.com/52844949/144978767-4adec207-48c0-43ca-bd26-413d1a772483.jpg" width="auto" height="640"/> 

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have filled the `[Unreleased]` [Changelog](https://github.com/nodefluxio/weber/blob/main/CHANGELOG.md)

## Security Pentester API Checklist
- [ ] IDOR
- [ ] Malicious Script Injection
- [ ] SQL Injection

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
