### PR TITLE
[Beat] Remove Base64 Input in Analytics/Innovation Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - [FRONTEND] Change face occlusion & attribute example one
 - [FRONTEND] Modified solution card stylings
 - [BACKEND] Update visitor activities endpoint for solution partner
+- [BACKEND] Replace base64 logging in analytics/innovation
 
 ### Removed
 

--- a/backend/controllers/innovation.go
+++ b/backend/controllers/innovation.go
@@ -180,7 +180,10 @@ func RequestToFaceOcclusionAttribute(ctx *gin.Context, postBody []byte) {
 	})
 
 	log.WithFields(log.Fields{
-		"data": serviceData,
+		"face_occlusion_message": serviceData.FaceOcclusion.Message,
+		"face_occlusion_ok":      serviceData.FaceOcclusion.Ok,
+		"face_attribute_message": serviceData.FaceAttribute.Message,
+		"face_attribute_ok":      serviceData.FaceAttribute.Ok,
 	}).Info("[CONTROLLER: RequestToFaceOcclusionAttribute] request to face occlusion atribute successfully done")
 
 }

--- a/backend/controllers/request.go
+++ b/backend/controllers/request.go
@@ -21,8 +21,9 @@ func RequestToServiceAnalytics(ctx *gin.Context, service models.Service, inputDa
 	var err error
 
 	log.WithFields(log.Fields{
-		"data_service": service,
-		"data_input":   inputData,
+		"data_service":      service,
+		"session_id":        inputData.SessionID,
+		"additional_params": inputData.Data.AdditionalParams,
 	}).Info("[CONTROLLER: RequestToServiceAnalytics] request to analytics service start...")
 
 	if service.Slug == "face-match-enrollment" {
@@ -68,8 +69,9 @@ func RequestToServiceInnovation(ctx *gin.Context, service models.Service, inputD
 	var serviceData models.ServiceRequestResultData
 
 	log.WithFields(log.Fields{
-		"data_service": service,
-		"data_input":   inputData,
+		"data_service":      service,
+		"session_id":        inputData.SessionID,
+		"additional_params": inputData.Data.AdditionalParams,
 	}).Info("[CONTROLLER: RequestToServiceInnovation] request to innovation service start...")
 
 	requestData := inputData.Data


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
Base64 input keprint pas nyoba analytic / innovation, bikin ngelag di local
Thanks @gregoriusjimmy udah ngingetin

## What is the new behavior?
Ganti jadi ngelog additional params dan session id

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
