### PR TITLE
fix modal X button position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- [FRONTEND] Fix X button position in Modal
+
 ### Removed
 
 ## [1.1.1 - 30/12/2021]

--- a/frontend/app/components/elements/Modal/Modal.tsx
+++ b/frontend/app/components/elements/Modal/Modal.tsx
@@ -23,7 +23,7 @@ export const Modal = ({ show, onClose, children }: Props) => {
       className="fixed top-0 right-0 left-0 bottom-0 
       w-full h-full flex justify-center items-center bg-black/50  z-50">
       <div className="bg-white w-[95%] py-8 px-4 relative rounded-2xl sm:w-[600px] overflow-y-auto max-h-[95vh] overflow-hidden">
-        <div className="absolute text-2xl top-8 right-4 ">
+        <div className="absolute text-2xl top-4 right-5 ">
           <a href="#" onClick={handleCloseClick}>
             x
           </a>


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
<!-- Please describe the current behavior. -->
The current X button in modal component is not near the corner

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Change position X button in modal to be near the corner

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have filled the `[Unreleased]` [Changelog](https://github.com/nodefluxio/weber/blob/main/CHANGELOG.md

## Security Pentester API Checklist
- [ ] IDOR
- [ ] Malicious Script Injection
- [ ] SQL Injection

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
before
![image](https://user-images.githubusercontent.com/45916985/148020216-e130e8d9-3269-4689-b102-00a2e1dd6b69.png)
after
![image](https://user-images.githubusercontent.com/45916985/148019726-f31a4210-3161-48c5-ad25-2857a8257418.png)
