### PR TITLE
[Backend] Add company size column on visitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
 ## [Unreleased]
 
+- [BACKEND] Add company size field
+
 ## [1.2.1 - 13/01/2022]
+
 ### Changed
 
 - [FRONTEND] Fix solution card external link
+
 ## [1.2.0 - 13/01/2022]
 
 ### Added
@@ -19,7 +24,6 @@ All notable changes to this project will be documented in this file.
 - [FRONTEND] Update solution card design
 - [FRONTEND] Change NIST logo to be smaller in larger device
 - [FRONTEND] Add Partner Solutions Carousel
-
 
 ### Removed
 

--- a/backend/models/visitor.go
+++ b/backend/models/visitor.go
@@ -7,14 +7,15 @@ import (
 )
 
 type Visitor struct {
-	SessionID string    `gorm:"primary_key" json:"session_id"`
-	Email     string    `json:"email" validate:"required,email"`
-	FullName  string    `json:"full_name" validate:"required,min=5,max=255"`
-	Company   string    `json:"company" validate:"required,min=5,max=255"`
-	JobTitle  string    `json:"job_title" validate:"required,min=5,max=255"`
-	Industry  string    `json:"industry" validate:"required,min=2,max=255"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	SessionID   string    `gorm:"primary_key" json:"session_id"`
+	Email       string    `json:"email" validate:"required,email"`
+	FullName    string    `json:"full_name" validate:"required,min=5,max=255"`
+	Company     string    `json:"company" validate:"required,min=5,max=255"`
+	JobTitle    string    `json:"job_title" validate:"required,min=5,max=255"`
+	Industry    string    `json:"industry" validate:"required,min=2,max=255"`
+	CompanySize string    `json:"company_size" validate:"required,min=2,max=255"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 func (m *Model) CreateVisitor(Visitor *Visitor) (err error) {


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Enhancement
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behaviour?
There is no company size column on the visitor table


## What is the new behavior?
Added company size column

## Does this introduce a breaking change?

- [x] Yes
- [ ] No
